### PR TITLE
Correct the github domain

### DIFF
--- a/components/index.page
+++ b/components/index.page
@@ -2,7 +2,7 @@
 <p>Maintainer.org exists to help open source developers find help maintaining their projects and communities.</p>
 
 <p>This is a tentative first draft, version 0.01 of Maintainer.org: 
-<a href="http://github.org/mhoye/maintainer.org">a Github Repo</a> 
+<a href="http://github.com/mhoye/maintainer.org">a Github Repo</a> 
 and <a href="feeds.html">a mailing list</a>. Anyone can sign up; posts are verified before approval.</p>
 
 <p>Suggestions and pull requests are welcomed.</p>


### PR DESCRIPTION
The link to github goes to .org (which just seems to timeout) instead of .com